### PR TITLE
fix(http): make test pass

### DIFF
--- a/http/http_test.go
+++ b/http/http_test.go
@@ -4,25 +4,31 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"testing"
 )
 
 func TestServeMux(t *testing.T) {
 	var s Server
-	// s.RootDir = t.TempDir()
+	s.RootDir = t.TempDir()
 
-	f, err := os.CreateTemp("", "index.html")
+	f, err := os.Create(path.Join(s.RootDir, "index.html"))
+	if err != nil {
+		t.Fatalf("Error creating file: %v", err)
+	}
 
-	// fname := filepath.Join(s.RootDir, "index.html")
-	// fmt.Printf("fname: %v", fname)
+	if _, err = f.WriteString("Hello, world!"); err != nil {
+		t.Fatalf("Error writing file: %v", err)
+	}
 
 	mux := s.SetupMux()
+
 	// Create a testing server with the ServeMux
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
 	// Test GET request
-	resp, err := http.Get(ts.URL + f.Name())
+	resp, err := http.Get(ts.URL)
 	if err != nil {
 		t.Errorf("Error making GET request: %v", err)
 	}


### PR DESCRIPTION
1. Use t.TempDir for the temporary file, using os.CreateTemp would also work, but it would mean we need to compute the directory from the filename. I find using path.Join to be clearer.
2. Write an arbitrary string to it, we just need some content.
3. Make `GET /`, to trigger the getIndex function.