### PR TITLE
refactor: http assets, file path

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -214,7 +214,7 @@ func (s Server) getStaticAsset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fp := u.Path[len("/"):]
+	fp := u.Path[1:]
 
 	asset, err := s.EmbedRootDir.ReadFile(fp)
 	if err != nil {


### PR DESCRIPTION
- [x] https://github.com/riraum/si-cheong/blob/2d498a13ab9596151604e340fa794d1c2842040b/http/http.go#L219 the len is always gonna be `1`, why not use `1` here?