### PR TITLE
refactor: au

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -18,23 +18,23 @@ type Author struct {
 }
 
 type Post struct {
-	ID            float32
-	Date          int64
-	ParsedDate    time.Time
-	Title         string
-	Link          string
-	Content       string
-	AuthorID      float32 // Author.ID
-	Authenticated bool
-	Today         time.Time
-	AuthorName    string
+	ID         float32
+	Date       int64
+	ParsedDate time.Time
+	Title      string
+	Link       string
+	Content    string
+	AuthorID   float32 // Author.ID
+	// Authenticated bool
+	// Today         time.Time
+	// AuthorName string
 }
 
 type Posts struct {
-	Authenticated bool
-	Today         time.Time
-	Posts         []Post
-	AuthorName    string
+	// Authenticated bool
+	// Today      time.Time
+	Posts []Post
+	// AuthorName string
 }
 
 type Params struct {

--- a/static/index.html.tmpl
+++ b/static/index.html.tmpl
@@ -15,7 +15,7 @@
 <body>
     <main class="container">
     <div>
-        {{if .Authenticated}}
+        {{if .auth}}
         <a href="logout">
             <button>{{.AuthorName}} log out</button>
         </a>

--- a/static/post.html.tmpl
+++ b/static/post.html.tmpl
@@ -26,7 +26,7 @@
     {{.AuthorName}}
     <br>
   </div>
-  {{if .Authenticated}}
+  {{if .}}
     <form action="/post/delete/{{.ID}}" method="POST" novalidate>
       <input type="submit" value="Delete" />
   </form>


### PR DESCRIPTION
- [ ] https://github.com/riraum/si-cheong/blob/2d498a13ab9596151604e340fa794d1c2842040b/db/db.go#L28 and https://github.com/riraum/si-cheong/blob/2d498a13ab9596151604e340fa794d1c2842040b/db/db.go#L34
  It is wrong that the post(s) are authenticated, because they aren't. The user is authenticated.
  You use it for https://github.com/riraum/si-cheong/blob/2d498a13ab9596151604e340fa794d1c2842040b/http/http.go#L245-L253, but you should instead wrap the `Post(s)` and `Authenticated` into a struct, instead of injecting `Authenticated` into `Post(s)`.
- [ ] https://github.com/riraum/si-cheong/blob/2d498a13ab9596151604e340fa794d1c2842040b/db/db.go#L35 why do you need to store today here?

- add struct for post(s) WIP adjust templates