### PR TITLE
sec(http): add IdleTimeout

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -50,11 +50,12 @@ func (s Server) SetupMux() *http.ServeMux {
 
 func Run(mux *http.ServeMux) {
 	srv := &http.Server{
-		ReadTimeout:  5 * time.Second,   //nolint:mnd
-		WriteTimeout: 10 * time.Second,  //nolint:mnd
-		IdleTimeout:  120 * time.Second, //nolint:mnd
-		Handler:      mux,
-		Addr:         ":8081",
+		ReadHeaderTimeout: 4 * time.Second,   //nolint:mnd
+		ReadTimeout:       5 * time.Second,   //nolint:mnd
+		WriteTimeout:      10 * time.Second,  //nolint:mnd
+		IdleTimeout:       120 * time.Second, //nolint:mnd
+		Handler:           mux,
+		Addr:              ":8081",
 	}
 	log.Println(srv.ListenAndServe())
 }


### PR DESCRIPTION
Best practice to also add a `IdleTimeout` for the http server.
Added `ReadHeaderTimeout` too.

resources:
https://blog.cloudflare.com/exposing-go-on-the-internet/
https://adam-p.ca/blog/2022/01/golang-http-server-timeouts/