### PR TITLE
refactor(db): create db dir exist check

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -33,7 +33,7 @@ type InitialDB struct {
 
 func New(db InitialDB) (DB, error) {
 	if _, err := os.Stat(db.Directory); errors.Is(err, os.ErrNotExist) {
-		if err := os.Mkdir(db.Directory, 0755); err != nil {
+		if err := os.Mkdir(db.Directory, 0750); err != nil {
 			return DB{}, fmt.Errorf("failed to create dir %w", err)
 		}
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -2,8 +2,10 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	_ "github.com/mattn/go-sqlite3" //revive be gone
 )
@@ -24,21 +26,22 @@ type DB struct {
 	client *sql.DB
 }
 
-func New(dbPath string) (DB, error) {
-	// testDBPath := "litefs/test.db"
-	// if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
-	// 	if _, err = os.Create(dbPath); err != nil {
-	// 		return DB{}, fmt.Errorf("failed to create db file %w", err)
-	// 	}
-	// }
-	d, err := sql.Open("sqlite3", dbPath)
+type InitialDB struct {
+	Directory string
+	Name      string
+}
+
+func New(db InitialDB) (DB, error) {
+	if _, err := os.Stat(db.Directory); errors.Is(err, os.ErrNotExist) {
+		if err := os.Mkdir(db.Directory, 0755); err != nil {
+			return DB{}, fmt.Errorf("failed to create dir %w", err)
+		}
+	}
+
+	d, err := sql.Open("sqlite3", (db.Directory + "/" + db.Name))
 	if err != nil {
 		return DB{}, fmt.Errorf("failed to open sql %w", err)
 	}
-
-	// if err = createTables(d); err != nil {
-	// 	return DB{}, fmt.Errorf("failed to create tables %w", err)
-	// }
 
 	return DB{d}, nil
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"log"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -17,7 +16,10 @@ func noTimeStamps(Post Posts) {
 }
 
 func TestAll(t *testing.T) {
-	testDB := filepath.Join(t.TempDir(), "test.db")
+	testDB := InitialDB{
+		Directory: t.TempDir(),
+		Name:      "test.db",
+	}
 
 	d, err := New(testDB)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -22,13 +22,16 @@ func main() {
 		log.Fatalf("key fail: %v", err)
 	}
 
-	dbPath := "litefs/sq.db"
+	dbPrefs := db.InitialDB{
+		Directory: "litefs",
+		Name:      "sq.db",
+	}
 
 	// Uncomment to reset/remove db.
 	// TODO: make this easier to run, maybe CLI flag.
 	// os.Remove(dbPath)
 
-	d, err := db.New(dbPath)
+	d, err := db.New(dbPrefs)
 	if err != nil {
 		log.Printf("failed to open db %v", err)
 	}


### PR DESCRIPTION
Create db dir when not existing, when existing use existing db file or create new one.
Should work better with local, fly.io and render.com deployment and account for initial runs locally, initial runs on fly.io with mounted persistent volume and on render.com with current non persistent storage.